### PR TITLE
chore(src): improve containerd support.

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,7 +163,7 @@ load_plugins: [container]
 By default, all engines are enabled on **default sockets**:
 * Docker: `/var/run/docker.sock`
 * Podman: `/run/podman/podman.sock` for root, + `/run/user/$uid/podman/podman.sock` for each user in the system
-* Containerd: [`/run/containerd/containerd.sock`, `/run/k3s/containerd/containerd.sock`]
+* Containerd: [`/run/containerd/containerd.sock`, `/run/k3s/containerd/containerd.sock`, `/run/host-containerd/containerd.sock`]
 * Cri: `/run/crio/crio.sock`
 
 ### Rules

--- a/TODO.md
+++ b/TODO.md
@@ -6,7 +6,6 @@ Remaining unsupported fields:
 * Containerd:
   - [ ] Ip
   - [ ] fix image related fields being empty when a docker container is spawned
-- [ ] all healthprobe related infos
 
 - [ ] fix: docker is not able to retrieve IP because onContainerCreate is called too early
 - [ ] Implement support for [`cri_extra_queries`](https://github.com/falcosecurity/libs/blob/bd0bb9baf273acc346dec881ec1d264911d74893/userspace/libsinsp/cri.hpp#L837)? It is enabled by default and moreover it does not seem needed with current code

--- a/TODO.md
+++ b/TODO.md
@@ -1,5 +1,16 @@
 # TODO
 
+Remaining unsupported fields:
+* CRI:
+  - [ ] CniJson
+* Containerd:
+  - [ ] Ip
+  - [ ] fix image related fields being empty when a docker container is spawned
+- [ ] all healthprobe related infos
+
+- [ ] fix: docker is not able to retrieve IP because onContainerCreate is called too early
+- [ ] Implement support for [`cri_extra_queries`](https://github.com/falcosecurity/libs/blob/bd0bb9baf273acc346dec881ec1d264911d74893/userspace/libsinsp/cri.hpp#L837)? It is enabled by default and moreover it does not seem needed with current code
+
 - [x] reimplement `sinsp_container_manager::identify_category()` : https://github.com/falcosecurity/libs/blob/master/userspace/libsinsp/container.cpp#L488
   - [x] finish implementing identify_category logic
 
@@ -15,10 +26,6 @@
     * if clone/exexve syscalls are lost the plugin won't receive them and thus container_id won't be written -> this already happens in sinsp
     * the latter can be fixed by letting `extract` write the foreign key in the threadtable, so that we store the thread container_id during extraction
 
-- [ ] properly send json with all info from go-worker
-    - [ ] fix remaining TODOs
-    - [ ] fix: docker is not able to retrieve IP because onContainerCreate is called too early
-    - [ ] send healthprobe related infos
 
 - [x] Implement containerd matcher
 - [x] Implement some unit tests taken from sinsp

--- a/go-worker/main_exe.go
+++ b/go-worker/main_exe.go
@@ -22,7 +22,7 @@ func main() {
 	initCfg := `
    {
       "label_max_len": 100,
-      "with_size": false,
+      "with_size": true,
       "engines": {
 		  "containerd":{
 			 "enabled":true,

--- a/go-worker/pkg/container/containerd.go
+++ b/go-worker/pkg/container/containerd.go
@@ -131,6 +131,8 @@ func (c *containerdEngine) ctrToInfo(namespacedContext context.Context, containe
 		imageTag    string
 		imageSize   int64 = -1
 	)
+	// TODO this is an extra API call; shall we move it behing config.GetWithSize()?
+	// Or rename `with_size` option with something more generic like `full_info`?
 	image, _ := container.Image(namespacedContext)
 	if image != nil {
 		imageDigest = image.Target().Digest.String()

--- a/go-worker/pkg/container/cri_test.go
+++ b/go-worker/pkg/container/cri_test.go
@@ -2,6 +2,7 @@ package container
 
 import (
 	"context"
+	"encoding/json"
 	"github.com/FedeDP/container-worker/pkg/event"
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"
@@ -13,6 +14,191 @@ import (
 	"testing"
 	"time"
 )
+
+func TestCRIInfoMap(t *testing.T) {
+	jsonInfo := `
+{
+"sandboxID": "7c81e23f249ed06a6a804edcc89eb74e3c44e326257d8709db3a7a74bbbd2efb",
+"pid": 0,
+"removing": false,
+"snapshotKey": "570b00d1f91393c91dfc131d7887f37def66902e360e63a7526e7c74fae53c0d",
+"snapshotter": "overlayfs",
+"runtimeType": "io.containerd.runc.v2",
+"runtimeOptions": null,
+"config": {
+  "metadata": {
+	"name": "test_container"
+  },
+  "image": {
+	"image": "alpine:3.20.3"
+  },
+  "envs": [
+	{
+	  "key": "test",
+	  "value": "container"
+	}
+  ],
+  "labels": {
+	"foo": "bar"
+  },
+  "linux": {
+	"resources": {
+	  "cpu_quota": 2000,
+	  "cpuset_cpus": "1-3"
+	},
+	"security_context": {}
+  }
+},
+"runtimeSpec": {
+  "ociVersion": "1.1.0",
+  "process": {
+	"user": {
+	  "uid": 0,
+	  "gid": 0,
+	  "additionalGids": [
+		0,
+		1,
+		2,
+		3,
+		4,
+		6,
+		10,
+		11,
+		20,
+		26,
+		27
+	  ]
+	},
+	"args": [
+	  "/bin/sh"
+	],
+	"env": [
+	  "PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin",
+	  "HOSTNAME=federico.dipierro",
+	  "test=container"
+	],
+	"cwd": "/",
+	"capabilities": {
+	  "bounding": [
+		"CAP_CHOWN",
+		"CAP_DAC_OVERRIDE",
+		"CAP_FSETID",
+		"CAP_FOWNER",
+		"CAP_MKNOD",
+		"CAP_NET_RAW",
+		"CAP_SETGID",
+		"CAP_SETUID",
+		"CAP_SETFCAP",
+		"CAP_SETPCAP",
+		"CAP_NET_BIND_SERVICE",
+		"CAP_SYS_CHROOT",
+		"CAP_KILL",
+		"CAP_AUDIT_WRITE"
+	  ],
+	  "effective": [
+		"CAP_CHOWN",
+		"CAP_DAC_OVERRIDE",
+		"CAP_FSETID",
+		"CAP_FOWNER",
+		"CAP_MKNOD",
+		"CAP_NET_RAW",
+		"CAP_SETGID",
+		"CAP_SETUID",
+		"CAP_SETFCAP",
+		"CAP_SETPCAP",
+		"CAP_NET_BIND_SERVICE",
+		"CAP_SYS_CHROOT",
+		"CAP_KILL",
+		"CAP_AUDIT_WRITE"
+	  ],
+	  "permitted": [
+		"CAP_CHOWN",
+		"CAP_DAC_OVERRIDE",
+		"CAP_FSETID",
+		"CAP_FOWNER",
+		"CAP_MKNOD",
+		"CAP_NET_RAW",
+		"CAP_SETGID",
+		"CAP_SETUID",
+		"CAP_SETFCAP",
+		"CAP_SETPCAP",
+		"CAP_NET_BIND_SERVICE",
+		"CAP_SYS_CHROOT",
+		"CAP_KILL",
+		"CAP_AUDIT_WRITE"
+	  ]
+	},
+	"apparmorProfile": "cri-containerd.apparmor.d",
+	"oomScoreAdj": 0
+  },
+  "root": {
+	"path": "rootfs"
+  },
+  "mounts": [
+	{
+	  "destination": "/proc",
+	  "type": "proc",
+	  "source": "proc",
+	  "options": [
+		"nosuid",
+		"noexec",
+		"nodev"
+	  ]
+	},
+	{
+	  "destination": "/dev",
+	  "type": "tmpfs",
+	  "source": "tmpfs",
+	  "options": [
+		"nosuid",
+		"strictatime",
+		"mode=755",
+		"size=65536k"
+	  ]
+	}
+  ],
+  "annotations": {
+	"io.kubernetes.cri.container-name": "test_container",
+	"io.kubernetes.cri.container-type": "container",
+	"io.kubernetes.cri.image-name": "docker.io/library/alpine:3.20.3",
+	"io.kubernetes.cri.sandbox-id": "7c81e23f249ed06a6a804edcc89eb74e3c44e326257d8709db3a7a74bbbd2efb",
+	"io.kubernetes.cri.sandbox-name": "test",
+	"io.kubernetes.cri.sandbox-namespace": "default",
+	"io.kubernetes.cri.sandbox-uid": "04688d49-005b-46ec-a200-18ed04a954fb"
+  },
+  "linux": {
+	"resources": {
+	  "devices": [
+		{
+		  "allow": false,
+		  "access": "rwm"
+		}
+	  ],
+	  "memory": {},
+	  "cpu": {
+		"quota": 2000,
+		"cpus": "1-3"
+	  }
+	},
+	"cgroupsPath": "/k8s.io/570b00d1f91393c91dfc131d7887f37def66902e360e63a7526e7c74fae53c0d",
+	"namespaces": [
+	  {
+		"type": "pid",
+		"path": "/proc/293715/ns/pid"
+	  },
+	  {
+		"type": "ipc",
+		"path": "/proc/293715/ns/ipc"
+	  }
+	]
+  }
+}
+}
+`
+	var ctrInfo criInfo
+	err := json.Unmarshal([]byte(jsonInfo), &ctrInfo)
+	assert.NoError(t, err)
+}
 
 func TestCRIFake(t *testing.T) {
 	endpoint, err := fake.GenerateEndpoint()
@@ -64,19 +250,20 @@ func TestCRIFake(t *testing.T) {
 				ID:               "test_sandbox",
 				Name:             "test_container",
 				Image:            "alpine:3.20.3",
-				ImageDigest:      "alpine:3.20.3",
+				ImageDigest:      "",
+				ImageID:          "",
 				ImageRepo:        "alpine",
 				ImageTag:         "3.20.3",
-				User:             "&ContainerUser{Linux:nil,}",
+				User:             "0",
 				CPUPeriod:        defaultCpuPeriod,
 				CPUQuota:         0,
 				CPUShares:        defaultCpuShares,
 				CPUSetCPUCount:   0,
-				Env:              nil, // TODO
+				Env:              nil, // not returned in fake mode
 				FullID:           "test_sandbox_test_container_0",
 				Labels:           map[string]string{"foo": "bar", "io.kubernetes.sandbox.id": "test_sandbox_test_container_0"},
 				PodSandboxID:     "test_sandbox_test_container_0",
-				Privileged:       false, // TODO
+				Privileged:       false,
 				PodSandboxLabels: map[string]string{},
 				Mounts:           []event.Mount{},
 				Size:             -1,
@@ -164,22 +351,23 @@ func TestCRI(t *testing.T) {
 		Info: event.Info{
 			Container: event.Container{
 				Type:             typeContainerd.ToCTValue(),
-				ID:               ctr[:shortIDLength],
+				ID:               shortContainerID(ctr),
 				Name:             "test_container",
 				Image:            "docker.io/library/alpine:3.20.3",
-				ImageDigest:      "docker.io/library/alpine@sha256:1e42bbe2508154c9126d48c2b8a75420c3544343bf86fd041fb7527e017a4b4a",
+				ImageDigest:      "sha256:1e42bbe2508154c9126d48c2b8a75420c3544343bf86fd041fb7527e017a4b4a",
+				ImageID:          "3.20.3",
 				ImageRepo:        "docker.io/library/alpine",
 				ImageTag:         "3.20.3",
-				User:             "&ContainerUser{Linux:nil,}",
+				User:             "0",
 				CPUPeriod:        defaultCpuPeriod,
 				CPUQuota:         2000,
 				CPUShares:        defaultCpuShares,
 				CPUSetCPUCount:   3,
-				Env:              nil, // TODO
+				Env:              []string{"test=container"},
 				FullID:           ctr,
 				Labels:           map[string]string{"foo": "bar", "io.kubernetes.sandbox.id": sandboxName, "io.kubernetes.pod.name": "test", "io.kubernetes.pod.namespace": "default", "io.kubernetes.pod.uid": id.String()},
 				PodSandboxID:     sandboxName,
-				Privileged:       false, // TODO
+				Privileged:       false,
 				PodSandboxLabels: map[string]string{},
 				Mounts:           []event.Mount{},
 				IsPodSandbox:     true,

--- a/go-worker/pkg/container/docker.go
+++ b/go-worker/pkg/container/docker.go
@@ -176,7 +176,7 @@ func (dc *dockerEngine) ctrToInfo(ctx context.Context, ctr types.ContainerJSON) 
 	return event.Info{
 		Container: event.Container{
 			Type:           typeDocker.ToCTValue(),
-			ID:             ctr.ID[:shortIDLength],
+			ID:             shortContainerID(ctr.ID),
 			Name:           name,
 			Image:          cfg.Image,
 			ImageDigest:    imageDigest,
@@ -222,7 +222,7 @@ func (dc *dockerEngine) List(ctx context.Context) ([]event.Event, error) {
 				Info: event.Info{
 					Container: event.Container{
 						Type:        typeDocker.ToCTValue(),
-						ID:          ctr.ID[:shortIDLength],
+						ID:          shortContainerID(ctr.ID),
 						Image:       ctr.Image,
 						FullID:      ctr.ID,
 						ImageID:     ctr.ImageID,
@@ -268,7 +268,7 @@ func (dc *dockerEngine) Listen(ctx context.Context, wg *sync.WaitGroup) (<-chan 
 						Info: event.Info{
 							Container: event.Container{
 								Type:   typeDocker.ToCTValue(),
-								ID:     msg.Actor.ID[:shortIDLength],
+								ID:     shortContainerID(msg.Actor.ID),
 								FullID: msg.Actor.ID,
 								Image:  msg.Actor.Attributes["image"],
 							},

--- a/go-worker/pkg/container/docker_test.go
+++ b/go-worker/pkg/container/docker_test.go
@@ -36,6 +36,9 @@ func TestDocker(t *testing.T) {
 		Env:    []string{"env=env"},
 		Image:  "alpine:3.20.3",
 		Labels: map[string]string{"foo": "bar"},
+		Healthcheck: &container.HealthConfig{
+			Test: []string{"CMD", "/tmp/foo", "bar"},
+		},
 	}, &container.HostConfig{
 		Privileged: true,
 		Resources: container.Resources{
@@ -71,6 +74,10 @@ func TestDocker(t *testing.T) {
 				Mounts:         []event.Mount{},
 				PortMappings:   []event.PortMapping{},
 				Size:           -1,
+				HealthcheckProbe: &event.Probe{
+					Exe:  "/tmp/foo",
+					Args: []string{"bar"},
+				},
 			}},
 		IsCreate: true,
 	}

--- a/go-worker/pkg/container/engine.go
+++ b/go-worker/pkg/container/engine.go
@@ -200,3 +200,10 @@ func countCPUSet(cpuSet string) int64 {
 	}
 	return counter
 }
+
+func shortContainerID(id string) string {
+	if len(id) > shortIDLength {
+		return id[:shortIDLength]
+	}
+	return id
+}

--- a/go-worker/pkg/container/podman.go
+++ b/go-worker/pkg/container/podman.go
@@ -118,7 +118,7 @@ func (pc *podmanEngine) ctrToInfo(ctr *define.InspectContainerData) event.Info {
 	return event.Info{
 		Container: event.Container{
 			Type:           typePodman.ToCTValue(),
-			ID:             ctr.ID[:shortIDLength],
+			ID:             shortContainerID(ctr.ID),
 			Name:           name,
 			Image:          ctr.ImageName,
 			ImageDigest:    ctr.ImageDigest,
@@ -164,7 +164,7 @@ func (pc *podmanEngine) List(_ context.Context) ([]event.Event, error) {
 				Info: event.Info{
 					Container: event.Container{
 						Type:        typePodman.ToCTValue(),
-						ID:          c.ID[:shortIDLength],
+						ID:          shortContainerID(c.ID),
 						Image:       c.Image,
 						FullID:      c.ID,
 						ImageID:     c.ImageID,
@@ -230,7 +230,7 @@ func (pc *podmanEngine) Listen(ctx context.Context, wg *sync.WaitGroup) (<-chan 
 						Info: event.Info{
 							Container: event.Container{
 								Type:   typePodman.ToCTValue(),
-								ID:     ev.Actor.ID[:shortIDLength],
+								ID:     shortContainerID(ev.Actor.ID),
 								FullID: ev.Actor.ID,
 								Image:  ev.Actor.Attributes["image"],
 							},

--- a/go-worker/pkg/container/podman_test.go
+++ b/go-worker/pkg/container/podman_test.go
@@ -83,7 +83,7 @@ func TestPodman(t *testing.T) {
 		Info: event.Info{
 			Container: event.Container{
 				Type:           typePodman.ToCTValue(),
-				ID:             ctr.ID[:shortIDLength],
+				ID:             shortContainerID(ctr.ID),
 				Name:           "test_container",
 				Image:          "docker.io/library/alpine:3.20.3",
 				ImageDigest:    "sha256:1e42bbe2508154c9126d48c2b8a75420c3544343bf86fd041fb7527e017a4b4a",
@@ -135,7 +135,7 @@ func TestPodman(t *testing.T) {
 		Info: event.Info{
 			Container: event.Container{
 				Type:   typePodman.ToCTValue(),
-				ID:     ctr.ID[:shortIDLength],
+				ID:     shortContainerID(ctr.ID),
 				FullID: ctr.ID,
 				Image:  "docker.io/library/alpine:3.20.3",
 			}},

--- a/go-worker/pkg/container/podman_test.go
+++ b/go-worker/pkg/container/podman_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"github.com/FedeDP/container-worker/pkg/event"
+	"github.com/containers/image/v5/manifest"
 	"github.com/containers/podman/v5/pkg/bindings"
 	"github.com/containers/podman/v5/pkg/bindings/containers"
 	"github.com/containers/podman/v5/pkg/bindings/images"
@@ -73,6 +74,11 @@ func TestPodman(t *testing.T) {
 				},
 			},
 		},
+		ContainerHealthCheckConfig: specgen.ContainerHealthCheckConfig{
+			HealthConfig: &manifest.Schema2HealthConfig{
+				Test: []string{"CMD-SHELL", "echo hello world"},
+			},
+		},
 	}, nil)
 	assert.NoError(t, err)
 
@@ -101,6 +107,10 @@ func TestPodman(t *testing.T) {
 				Mounts:         []event.Mount{},
 				PortMappings:   []event.PortMapping{},
 				Size:           -1,
+				HealthcheckProbe: &event.Probe{
+					Exe:  "/bin/sh",
+					Args: []string{"-c", "echo hello world"},
+				},
 			}},
 		IsCreate: true,
 	}

--- a/go-worker/pkg/event/event.go
+++ b/go-worker/pkg/event/event.go
@@ -21,7 +21,6 @@ type Probe struct {
 	Args []string `json:"args"`
 }
 
-// TODO implement healtcheck/liveness/readiness probe related fields
 type Container struct {
 	Type             int               `json:"type"`
 	ID               string            `json:"id"`

--- a/src/extract.cpp
+++ b/src/extract.cpp
@@ -561,22 +561,22 @@ bool my_plugin::extract(const falcosecurity::extract_fields_input& in) {
                 if (m_containers.count(sandbox_id) > 0) {
                     sandbox_container_info = m_containers[sandbox_id];
                 }
-                if (field_id == TYPE_K8S_POD_LABEL) {
-                    auto arg_key = req.get_arg_key();
-                    if (sandbox_container_info && sandbox_container_info->m_pod_sandbox_labels.count(arg_key) > 0) {
-                        req.set_value(sandbox_container_info->m_pod_sandbox_labels.at(arg_key));
-                    } else if (cinfo->m_pod_sandbox_labels.count(arg_key) > 0) {
-                        req.set_value(cinfo->m_pod_sandbox_labels.at(arg_key));
-                    }
-                } else {
-                    std::string labels;
-                    if (sandbox_container_info) {
-                        concatenate_container_labels(sandbox_container_info->m_pod_sandbox_labels, &labels);
-                    } else {
-                        concatenate_container_labels(cinfo->m_pod_sandbox_labels, &labels);
-                    }
-                    req.set_value(labels);
+            }
+            if (field_id == TYPE_K8S_POD_LABEL) {
+                auto arg_key = req.get_arg_key();
+                if (sandbox_container_info && sandbox_container_info->m_pod_sandbox_labels.count(arg_key) > 0) {
+                    req.set_value(sandbox_container_info->m_pod_sandbox_labels.at(arg_key));
+                } else if (cinfo->m_pod_sandbox_labels.count(arg_key) > 0) {
+                    req.set_value(cinfo->m_pod_sandbox_labels.at(arg_key));
                 }
+            } else {
+                std::string labels;
+                if (sandbox_container_info) {
+                    concatenate_container_labels(sandbox_container_info->m_pod_sandbox_labels, &labels);
+                } else {
+                    concatenate_container_labels(cinfo->m_pod_sandbox_labels, &labels);
+                }
+                req.set_value(labels);
             }
             break;
         }

--- a/src/matchers/containerd.cpp
+++ b/src/matchers/containerd.cpp
@@ -1,14 +1,26 @@
 #include "containerd.h"
 #include "runc.h"
+#include <iostream>
+#include <sstream> // for ostringstream
+#include <re2/re2.h>
 
 using namespace libsinsp::runc;
 
-// Containers created via ctr
-// use the "default" namespace (instead of the cri "k8s.io" namespace)
-// which will result in the `/default` cgroup path.
-// https://github.com/containerd/containerd/blob/3b15606e196e450cf817fa9f835ab5324b35a28b/pkg/namespaces/context.go#L32
-constexpr const cgroup_layout CONTAINERD_CGROUP_LAYOUT[] = {{"/default/", ""}, {nullptr, nullptr}};
+static re2::RE2 pattern("^/([A-Za-z0-9]+(?:[._-](?:[A-Za-z0-9]+))*)/$", re2::RE2::POSIX);
 
 bool containerd::resolve(const std::string& cgroup, std::string& container_id) {
-    return matches_runc_cgroup(cgroup, CONTAINERD_CGROUP_LAYOUT, container_id);
+	std::string containerd_namespace;
+	// Containers created via ctr
+	// use a cgroup path like: `0::/namespace/container_id`
+	// Since we cannot know the namespace in advance, we try to
+	// extract it from the cgroup path by following provided regex,
+	// and use that to eventually extract the container id.
+	if(re2::RE2::PartialMatch(cgroup, pattern, &containerd_namespace)) {
+		std::ostringstream out;
+		out << "/" << containerd_namespace << "/";
+		auto layout_str = out.str();
+		cgroup_layout CONTAINERD_CGROUP_LAYOUT[] = {{layout_str.c_str(), ""}, {nullptr, nullptr}};
+		return matches_runc_cgroup(cgroup, CONTAINERD_CGROUP_LAYOUT, container_id);
+	}
+	return false;
 }

--- a/src/matchers/containerd.cpp
+++ b/src/matchers/containerd.cpp
@@ -6,7 +6,7 @@
 
 using namespace libsinsp::runc;
 
-static re2::RE2 pattern("^/([A-Za-z0-9]+(?:[._-](?:[A-Za-z0-9]+))*)/$", re2::RE2::POSIX);
+static re2::RE2 pattern("/([A-Za-z0-9]+(?:[._-](?:[A-Za-z0-9]+))*)/");
 
 bool containerd::resolve(const std::string& cgroup, std::string& container_id) {
 	std::string containerd_namespace;
@@ -20,7 +20,7 @@ bool containerd::resolve(const std::string& cgroup, std::string& container_id) {
 		out << "/" << containerd_namespace << "/";
 		auto layout_str = out.str();
 		cgroup_layout CONTAINERD_CGROUP_LAYOUT[] = {{layout_str.c_str(), ""}, {nullptr, nullptr}};
-		return matches_runc_cgroup(cgroup, CONTAINERD_CGROUP_LAYOUT, container_id);
+		return matches_runc_cgroup(cgroup, CONTAINERD_CGROUP_LAYOUT, container_id, true);
 	}
 	return false;
 }

--- a/src/matchers/containerd.cpp
+++ b/src/matchers/containerd.cpp
@@ -3,6 +3,10 @@
 
 using namespace libsinsp::runc;
 
+// Containers created via ctr
+// use the "default" namespace (instead of the cri "k8s.io" namespace)
+// which will result in the `/default` cgroup path.
+// https://github.com/containerd/containerd/blob/3b15606e196e450cf817fa9f835ab5324b35a28b/pkg/namespaces/context.go#L32
 constexpr const cgroup_layout CONTAINERD_CGROUP_LAYOUT[] = {{"/default/", ""}, {nullptr, nullptr}};
 
 bool containerd::resolve(const std::string& cgroup, std::string& container_id) {

--- a/src/matchers/runc.cpp
+++ b/src/matchers/runc.cpp
@@ -3,7 +3,6 @@
 namespace {
 const size_t CONTAINER_ID_LENGTH = 64;
 const size_t REPORTED_CONTAINER_ID_LENGTH = 12;
-const char *CONTAINER_ID_VALID_CHARACTERS = "0123456789abcdefABCDEF";
 
 static_assert(REPORTED_CONTAINER_ID_LENGTH <= CONTAINER_ID_LENGTH,
 "Reported container ID length cannot be longer than actual length");
@@ -12,6 +11,25 @@ static_assert(REPORTED_CONTAINER_ID_LENGTH <= CONTAINER_ID_LENGTH,
 
 namespace libsinsp {
 namespace runc {
+
+inline static bool endswith(const std::string &s, const std::string &suffix) {
+	return s.rfind(suffix) == (s.size() - suffix.size());
+}
+
+inline static bool is_host(const std::string &cgroup) {
+	// A good approximation to minize false-positives is to exclude systemd suffixes.
+	if(endswith(cgroup, ".slice") || endswith(cgroup, ".service")) {
+		return true;
+	} else if(endswith(cgroup, ".scope")) {
+		if(cgroup.find("crio-") != std::string::npos ||
+		   cgroup.find("docker-") != std::string::npos) {
+			return false;
+		}
+		return true;
+	}
+
+	return false;
+}
 
 // check if cgroup ends with <prefix><container_id><suffix>
 // If true, set <container_id> to a truncated version of the id and return true.
@@ -31,16 +49,21 @@ bool match_one_container_id(const std::string &cgroup,
         return false;
     }
 
-    if(end_pos - start_pos != CONTAINER_ID_LENGTH) {
+    // In some container runtimes the container id is not
+    // necessarly CONTAINER_ID_LENGTH long and can be arbitrarly defined.
+    // To keep it simple we only discard the container id > of CONTAINER_ID_LENGTH.
+    if(end_pos - start_pos > CONTAINER_ID_LENGTH || end_pos - start_pos == 0) {
         return false;
     }
 
-    size_t invalid_ch_pos = cgroup.find_first_not_of(CONTAINER_ID_VALID_CHARACTERS, start_pos);
-    if(invalid_ch_pos < CONTAINER_ID_LENGTH) {
+    if(is_host(cgroup)) {
         return false;
     }
 
-    container_id = cgroup.substr(start_pos, REPORTED_CONTAINER_ID_LENGTH);
+    size_t reported_len = end_pos - start_pos >= REPORTED_CONTAINER_ID_LENGTH
+                                  ? REPORTED_CONTAINER_ID_LENGTH
+                                  : end_pos;
+    container_id = cgroup.substr(start_pos, reported_len);
     return true;
 }
 
@@ -52,7 +75,6 @@ bool matches_runc_cgroup(const std::string &cgroup,
             return true;
         }
     }
-
     return false;
 }
 }  // namespace runc

--- a/src/matchers/runc.cpp
+++ b/src/matchers/runc.cpp
@@ -3,6 +3,7 @@
 namespace {
 const size_t CONTAINER_ID_LENGTH = 64;
 const size_t REPORTED_CONTAINER_ID_LENGTH = 12;
+const char *CONTAINER_ID_VALID_CHARACTERS = "0123456789abcdefABCDEF";
 
 static_assert(REPORTED_CONTAINER_ID_LENGTH <= CONTAINER_ID_LENGTH,
 "Reported container ID length cannot be longer than actual length");
@@ -16,28 +17,14 @@ inline static bool endswith(const std::string &s, const std::string &suffix) {
 	return s.rfind(suffix) == (s.size() - suffix.size());
 }
 
-inline static bool is_host(const std::string &cgroup) {
-	// A good approximation to minize false-positives is to exclude systemd suffixes.
-	if(endswith(cgroup, ".slice") || endswith(cgroup, ".service")) {
-		return true;
-	} else if(endswith(cgroup, ".scope")) {
-		if(cgroup.find("crio-") != std::string::npos ||
-		   cgroup.find("docker-") != std::string::npos) {
-			return false;
-		}
-		return true;
-	}
-
-	return false;
-}
-
 // check if cgroup ends with <prefix><container_id><suffix>
 // If true, set <container_id> to a truncated version of the id and return true.
 // Otherwise return false and leave container_id unchanged
 bool match_one_container_id(const std::string &cgroup,
                             const std::string &prefix,
                             const std::string &suffix,
-                            std::string &container_id) {
+                            std::string &container_id,
+                            bool is_containerd) {
     size_t start_pos = cgroup.rfind(prefix);
     if(start_pos == std::string::npos) {
         return false;
@@ -49,29 +36,38 @@ bool match_one_container_id(const std::string &cgroup,
         return false;
     }
 
-    // In some container runtimes the container id is not
+    if(end_pos - start_pos == CONTAINER_ID_LENGTH &&
+       cgroup.find_first_not_of(CONTAINER_ID_VALID_CHARACTERS, start_pos) >= CONTAINER_ID_LENGTH) {
+        container_id = cgroup.substr(start_pos, REPORTED_CONTAINER_ID_LENGTH);
+        return true;
+    }
+
+    // In some container runtimes the container the container id is not
     // necessarly CONTAINER_ID_LENGTH long and can be arbitrarly defined.
     // To keep it simple we only discard the container id > of CONTAINER_ID_LENGTH.
     if(end_pos - start_pos > CONTAINER_ID_LENGTH || end_pos - start_pos == 0) {
         return false;
     }
 
-    if(is_host(cgroup)) {
-        return false;
+    // For containerd, make sure to skip systemd host cgroups
+    if(is_containerd && !endswith(cgroup, ".service") &&
+       !endswith(cgroup, ".slice")) {
+        const size_t reported_len = end_pos - start_pos >= REPORTED_CONTAINER_ID_LENGTH
+                                      ? REPORTED_CONTAINER_ID_LENGTH
+                                      : end_pos - start_pos;
+        container_id = cgroup.substr(start_pos, reported_len);
+        return true;
     }
 
-    size_t reported_len = end_pos - start_pos >= REPORTED_CONTAINER_ID_LENGTH
-                                  ? REPORTED_CONTAINER_ID_LENGTH
-                                  : end_pos;
-    container_id = cgroup.substr(start_pos, reported_len);
-    return true;
+    return false;
 }
 
 bool matches_runc_cgroup(const std::string &cgroup,
                         const libsinsp::runc::cgroup_layout *layout,
-                        std::string &container_id) {
+                        std::string &container_id,
+                        bool is_containerd) {
     for(size_t i = 0; layout[i].prefix && layout[i].suffix; ++i) {
-        if(match_one_container_id(cgroup, layout[i].prefix, layout[i].suffix, container_id)) {
+        if(match_one_container_id(cgroup, layout[i].prefix, layout[i].suffix, container_id, is_containerd)) {
             return true;
         }
     }

--- a/src/matchers/runc.h
+++ b/src/matchers/runc.h
@@ -52,6 +52,7 @@ bool match_one_container_id(const std::string &cgroup,
  */
 bool matches_runc_cgroup(const std::string &cgroup,
                         const libsinsp::runc::cgroup_layout *layout,
-                        std::string &container_id);
+                        std::string &container_id,
+                        bool is_containerd=false);
 }  // namespace runc
 }  // namespace libsinsp

--- a/src/plugin_config.cpp
+++ b/src/plugin_config.cpp
@@ -52,6 +52,7 @@ void from_json(const nlohmann::json& j, PluginConfig& cfg) {
     if (cfg.containerd.sockets.empty()) {
         cfg.containerd.sockets.emplace_back("/run/containerd/containerd.sock");
         cfg.containerd.sockets.emplace_back("/run/k3s/containerd/containerd.sock");
+        cfg.containerd.sockets.emplace_back("/run/host-containerd/containerd.sock"); // bottlerocket host containers socket
     }
 }
 

--- a/test/matchers.cpp
+++ b/test/matchers.cpp
@@ -79,3 +79,25 @@ TEST_F(container_cgroup, containerd_unknown) {
 	EXPECT_EQ(true,  m_mgr.match_cgroup(cgroup, container_id, info));
 	EXPECT_EQ(expected_container_id, container_id);
 }
+
+TEST_F(container_cgroup, containerd) {
+	const std::string cgroup =
+	        "/default/test_container";
+	const std::string expected_container_id = "test_contain"; // first 12 chars
+
+	std::string container_id;
+	std::shared_ptr<container_info> info;
+	EXPECT_EQ(true,  m_mgr.match_cgroup(cgroup, container_id, info));
+	EXPECT_EQ(expected_container_id, container_id);
+}
+
+TEST_F(container_cgroup, containerd_namespaced) {
+	const std::string cgroup =
+	        "/my_very_long_namespace-1.5/test_container";
+	const std::string expected_container_id = "test_contain"; // first 12 chars
+
+	std::string container_id;
+	std::shared_ptr<container_info> info;
+	EXPECT_EQ(true,  m_mgr.match_cgroup(cgroup, container_id, info));
+	EXPECT_EQ(expected_container_id, container_id);
+}


### PR DESCRIPTION
Backport changes from https://github.com/falcosecurity/libs/pull/2195.

TODO:
- [x] currently our containerd matcher matches `/default/", ""` layout; this only works for containers created in the default namespace; try to support containers created under **any** namespace? The go-worker containerd subscribe already retrieves info for any container in any namespace; it is a matter of fixing the matcher.
- [x] Backport also changes to load all container infos in the go-worker (see https://github.com/therealbobo/libs/blob/513b0b57350cdeee0bdff0c4850b743c9974cc0d/userspace/libsinsp/container_engine/containerd.cpp)

Updated TODO with more info.
