### PR TITLE
new(ci): build CI plugins on golang:1.23-bullseye image, like the falcosecurity/plugins CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,72 +10,28 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  build-others:
-    strategy:
-      fail-fast: false
-      matrix:
-        os: [ windows-latest, macos-latest ]
-    runs-on: ${{ matrix.os }}
+  build:
+    uses: ./.github/workflows/reusable_build.yml
+    with:
+      caching_enabled: true
+    secrets: inherit
+
+  test:
+    # ubuntu24.04 for podman >= 4.x. x86_64 only,
+    # since podman is not shipped by beta github arm64 runners:
+    # https://github.com/actions/partner-runner-images/blob/main/images/arm-ubuntu-22-image.md#not-installed-software
+    # Building tests fail with: "faccessat /home/runneradmin/.config/containers/storage.conf: permission denied"
+    runs-on: 'ubuntu-24.04'
     steps:
-      # Needed by vcpkg caching
-      - name: Export GitHub Actions cache environment variables
-        uses: actions/github-script@v7
-        with:
-          script: |
-            core.exportVariable('ACTIONS_CACHE_URL', process.env.ACTIONS_CACHE_URL || '');
-            core.exportVariable('ACTIONS_RUNTIME_TOKEN', process.env.ACTIONS_RUNTIME_TOKEN || '');
+      # Needed by podman package - build and runtime dep.
+      - name: Install go test deps
+        run: sudo apt-get install -y --no-install-recommends libbtrfs-dev libgpgme-dev
 
       - name: Checkout
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
           submodules: 'recursive'
-
-      - name: Build plugin library (without ASYNC capability)
-        run: make
-        env:
-          VCPKG_BINARY_SOURCES: "clear;x-gha,readwrite"
-
-      - name: Upload artifact - windows
-        if: ${{ matrix.os == 'windows-latest' }}
-        uses: actions/upload-artifact@b4b15b8c7c6ac21ea08fcf65892d2ee8f75cf882 # v4.4.3
-        with:
-          name: libcontainer-win
-          path: 'container.dll'
-
-      - name: Upload artifact - osx
-        if: ${{ matrix.os == 'macos-latest' }}
-        uses: actions/upload-artifact@b4b15b8c7c6ac21ea08fcf65892d2ee8f75cf882 # v4.4.3
-        with:
-          name: libcontainer-osx
-          path: 'libcontainer.dylib'
-
-  build-and-test:
-    name: build-and-test-${{ matrix.arch }}
-    # ubuntu24.04 for podman >= 4.x
-    runs-on: ${{ (matrix.arch == 'arm64' && 'ubuntu-24.04-arm') || 'ubuntu-24.04' }}
-    strategy:
-      fail-fast: false
-      matrix:
-        arch: [ amd64, arm64 ]
-    steps:
-      # Needed by vcpkg caching
-      - name: Export GitHub Actions cache environment variables
-        uses: actions/github-script@v7
-        with:
-          script: |
-            core.exportVariable('ACTIONS_CACHE_URL', process.env.ACTIONS_CACHE_URL || '');
-            core.exportVariable('ACTIONS_RUNTIME_TOKEN', process.env.ACTIONS_RUNTIME_TOKEN || '');
-
-      - name: Checkout
-        uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-          submodules: 'recursive'
-
-      # Needed by containerd go package - build time dep, no runtime.
-      - name: Install plugin deps
-        run: sudo apt-get install -y --no-install-recommends libbtrfs-dev
 
       - name: Setup Go
         uses: actions/setup-go@v5
@@ -83,39 +39,18 @@ jobs:
           go-version-file: go-worker/go.mod
           cache-dependency-path: go-worker/go.sum
 
-      - name: Build plugin library
-        run: make
-        env:
-          VCPKG_BINARY_SOURCES: "clear;x-gha,readwrite"
-
-      - name: Upload artifact
-        uses: actions/upload-artifact@b4b15b8c7c6ac21ea08fcf65892d2ee8f75cf882 # v4.4.3
-        with:
-          name: libcontainer-${{ matrix.arch }}
-          path: 'libcontainer.so'
-
-      # Needed by podman package - build and runtime dep.
-      # For the go-worker library, it is only a runtime dep,
-      # and is provided by plugin vcpkg configuration.
-      - name: Install go-worker executable deps
-        run: sudo apt-get install -y --no-install-recommends libgpgme-dev
-
       - name: Build go-worker executable
         run: make -C go-worker exe
 
-      # Podman is not shipped by beta github arm64 runners:
-      # https://github.com/actions/partner-runner-images/blob/main/images/arm-ubuntu-22-image.md#not-installed-software
-      # Building tests fail with: "faccessat /home/runneradmin/.config/containers/storage.conf: permission denied"
-      - name: Run tests (x64 only)
-        if: matrix.arch == 'amd64'
+      - name: Run tests
         run: |
           systemctl --user start podman
           make test
 
   falco-tests:
-    needs: [build-and-test]
+    needs: [build]
     name: falco-tests-${{ matrix.arch }}
-    runs-on: ${{ (matrix.arch == 'arm64' && 'ubuntu-24.04-arm') || 'ubuntu-24.04' }}
+    runs-on: ${{ (matrix.arch == 'arm64' && 'ubuntu-22.04-arm') || 'ubuntu-22.04' }}
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,78 +13,11 @@ permissions:
 
 jobs:
   build:
-    runs-on: ${{ (matrix.arch == 'arm64' && 'ubuntu-22.04-arm') || 'ubuntu-22.04' }}
-    strategy:
-      fail-fast: false
-      matrix:
-        arch: [ amd64, arm64 ]
-    container: golang:1.23-bullseye
-    steps:
-      # libbtrfs-dev is needed by containerd go package - build time dep, no runtime.
-      # Vcpkg also needs ninja since on arm64 VCPKG_FORCE_SYSTEM_BINARIES must be enabled.
-      - name: Install plugin deps
-        run: apt-get update && apt-get install -y --no-install-recommends git make build-essential autotools-dev automake libtool pkg-config libbtrfs-dev curl zip unzip tar ninja-build
-
-      - name: Install updated cmake version ⛓️
-        run: |
-          curl -L -o /tmp/cmake.tar.gz https://github.com/Kitware/CMake/releases/download/v3.31.4/cmake-3.31.4-linux-$(uname -m).tar.gz
-          gzip -d /tmp/cmake.tar.gz
-          tar -xpf /tmp/cmake.tar --directory=/tmp
-          cp -R /tmp/cmake-3.31.4-linux-$(uname -m)/* /usr
-          rm -rf /tmp/cmake-3.31.4-linux-$(uname -m)
-
-      - name: Checkout
-        uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-          submodules: 'recursive'
-
-      - name: Safe directory
-        run: git config --global --add safe.directory $GITHUB_WORKSPACE
-
-      - name: Build plugin library
-        env:
-          VCPKG_FORCE_SYSTEM_BINARIES: 'true'
-        run: make libcontainer.so
-
-      - name: Upload artifact
-        uses: actions/upload-artifact@b4b15b8c7c6ac21ea08fcf65892d2ee8f75cf882 # v4.4.3
-        with:
-          name: libcontainer-${{ matrix.arch }}
-          path: 'libcontainer.so'
-
-  build-others:
-    strategy:
-      fail-fast: false
-      matrix:
-        os: [ windows-latest, macos-latest ]
-    runs-on: ${{ matrix.os }}
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-          submodules: 'recursive'
-
-      - name: Build plugin library (without ASYNC capability)
-        run: make
-
-      - name: Upload artifact - windows
-        if: ${{ matrix.os == 'windows-latest' }}
-        uses: actions/upload-artifact@b4b15b8c7c6ac21ea08fcf65892d2ee8f75cf882 # v4.4.3
-        with:
-          name: libcontainer-win
-          path: 'container.dll'
-
-      - name: Upload artifact - osx
-        if: ${{ matrix.os == 'macos-latest' }}
-        uses: actions/upload-artifact@b4b15b8c7c6ac21ea08fcf65892d2ee8f75cf882 # v4.4.3
-        with:
-          name: libcontainer-osx
-          path: 'libcontainer.dylib'
+    uses: ./.github/workflows/reusable_build.yml
+    secrets: inherit
 
   release:
-    needs: [build, build-others]
+    needs: [build]
     runs-on: 'ubuntu-latest'
     steps:
       - name: Download amd64 plugin

--- a/.github/workflows/reusable_build.yml
+++ b/.github/workflows/reusable_build.yml
@@ -1,0 +1,115 @@
+name: Build plugin on all supported platforms
+
+on:
+  workflow_call:
+    inputs:
+      caching_enabled:
+        description: 'whether to enable vcpkg caching'
+        type: boolean
+        required: false
+        default: false
+
+jobs:
+  build-others:
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ windows-latest, macos-latest ]
+    runs-on: ${{ matrix.os }}
+    steps:
+      # Needed by vcpkg caching
+      - name: Export GitHub Actions cache environment variables
+        if: inputs.caching_enabled
+        uses: actions/github-script@v7
+        with:
+          script: |
+            core.exportVariable('ACTIONS_CACHE_URL', process.env.ACTIONS_CACHE_URL || '');
+            core.exportVariable('ACTIONS_RUNTIME_TOKEN', process.env.ACTIONS_RUNTIME_TOKEN || '');
+
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          submodules: 'recursive'
+
+      - name: Build plugin library (without ASYNC capability) - CACHED
+        if: inputs.caching_enabled
+        run: make
+        env:
+          VCPKG_BINARY_SOURCES: "clear;x-gha,readwrite"
+
+      - name: Build plugin library (without ASYNC capability)
+        if: inputs.caching_enabled != true
+        run: make
+
+      - name: Upload artifact - windows
+        if: ${{ matrix.os == 'windows-latest' }}
+        uses: actions/upload-artifact@b4b15b8c7c6ac21ea08fcf65892d2ee8f75cf882 # v4.4.3
+        with:
+          name: libcontainer-win
+          path: 'container.dll'
+
+      - name: Upload artifact - osx
+        if: ${{ matrix.os == 'macos-latest' }}
+        uses: actions/upload-artifact@b4b15b8c7c6ac21ea08fcf65892d2ee8f75cf882 # v4.4.3
+        with:
+          name: libcontainer-osx
+          path: 'libcontainer.dylib'
+
+  build-linux:
+    name: build-linux-${{ matrix.arch }}
+    runs-on: ${{ (matrix.arch == 'arm64' && 'ubuntu-22.04-arm') || 'ubuntu-22.04' }}
+    strategy:
+      fail-fast: false
+      matrix:
+        arch: [ amd64, arm64 ]
+    container: golang:1.23-bullseye
+    steps:
+      # Needed by vcpkg caching
+      - name: Export GitHub Actions cache environment variables
+        if: inputs.caching_enabled
+        uses: actions/github-script@v7
+        with:
+          script: |
+            core.exportVariable('ACTIONS_CACHE_URL', process.env.ACTIONS_CACHE_URL || '');
+            core.exportVariable('ACTIONS_RUNTIME_TOKEN', process.env.ACTIONS_RUNTIME_TOKEN || '');
+
+      # Needed by containerd go package - build time dep, no runtime.
+      - name: Install plugin deps
+        run: apt-get update && apt-get install -y --no-install-recommends git make build-essential autotools-dev automake libtool pkg-config libbtrfs-dev curl zip unzip tar ninja-build
+
+      - name: Install updated cmake version ⛓️
+        run: |
+          curl -L -o /tmp/cmake.tar.gz https://github.com/Kitware/CMake/releases/download/v3.31.4/cmake-3.31.4-linux-$(uname -m).tar.gz
+          gzip -d /tmp/cmake.tar.gz
+          tar -xpf /tmp/cmake.tar --directory=/tmp
+          cp -R /tmp/cmake-3.31.4-linux-$(uname -m)/* /usr
+          rm -rf /tmp/cmake-3.31.4-linux-$(uname -m)  
+
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          submodules: 'recursive'
+
+      - name: Safe directory
+        run: git config --global --add safe.directory $GITHUB_WORKSPACE
+
+      - name: Build plugin library - CACHED
+        run: make
+        if: inputs.caching_enabled
+        env:
+          VCPKG_BINARY_SOURCES: "clear;x-gha,readwrite"
+          VCPKG_FORCE_SYSTEM_BINARIES: 'true'
+
+      - name: Build plugin library
+        run: make
+        if: inputs.caching_enabled != true
+        env:
+          VCPKG_FORCE_SYSTEM_BINARIES: 'true'
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@b4b15b8c7c6ac21ea08fcf65892d2ee8f75cf882 # v4.4.3
+        with:
+          name: libcontainer-${{ matrix.arch }}
+          path: 'libcontainer.so'


### PR DESCRIPTION
Also, create a reusable workflow since the CI is basically the same for CI and RELEASE workflows.