### PR TITLE
fix(go-worker): properly account for HOST_ROOT env variable.

### DIFF
--- a/go-worker/pkg/config/config.go
+++ b/go-worker/pkg/config/config.go
@@ -2,6 +2,7 @@ package config
 
 import (
 	"encoding/json"
+	"os"
 )
 
 const defaultLabelMaxLen = 100
@@ -15,6 +16,7 @@ type EngineCfg struct {
 	SocketsEngines map[string]SocketsEngine `json:"engines"`
 	LabelMaxLen    int                      `json:"label_max_len"`
 	WithSize       bool                     `json:"with_size"`
+	HostRoot       string
 }
 
 var c EngineCfg
@@ -23,6 +25,7 @@ var c EngineCfg
 func init() {
 	c.LabelMaxLen = defaultLabelMaxLen
 	c.WithSize = false
+	c.HostRoot = os.Getenv("HOST_ROOT")
 }
 
 func Load(initCfg string) error {
@@ -43,4 +46,8 @@ func GetLabelMaxLen() int {
 
 func GetWithSize() bool {
 	return c.WithSize
+}
+
+func GetHostRoot() string {
+	return c.HostRoot
 }

--- a/go-worker/pkg/container/engine.go
+++ b/go-worker/pkg/container/engine.go
@@ -118,6 +118,8 @@ func Generators() ([]EngineGenerator, *EngineInotifier, error) {
 		}
 		// For each specified socket, return a closure to generate its engine
 		for _, socket := range eCfg.Sockets {
+			// Properly account for HOST_ROOT env variable
+			socket = filepath.Join(config.GetHostRoot(), socket)
 			if _, statErr := os.Stat(socket); os.IsNotExist(statErr) {
 				// Does not exist; emplace back an inotify listener
 				if engineNotifier.watcher == nil {


### PR DESCRIPTION
We used it in sinsp container engines impl:
* https://github.com/falcosecurity/libs/blob/0.20.0/userspace/libsinsp/container_engine/cri.cpp#L59
* https://github.com/falcosecurity/libs/blob/0.20.0/userspace/libsinsp/container_engine/docker/connection_linux.cpp#L63
* https://github.com/falcosecurity/libs/blob/0.20.0/userspace/libsinsp/container_engine/docker/podman.cpp#L156
* https://github.com/falcosecurity/libs/blob/0.20.0/userspace/libsinsp/container_engine/containerd.cpp#L157