### PR TITLE
chore(ci): arm runner now include podman.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,11 +17,12 @@ jobs:
     secrets: inherit
 
   test:
-    # ubuntu24.04 for podman >= 4.x. x86_64 only,
-    # since podman is not shipped by beta github arm64 runners:
-    # https://github.com/actions/partner-runner-images/blob/main/images/arm-ubuntu-22-image.md#not-installed-software
-    # Building tests fail with: "faccessat /home/runneradmin/.config/containers/storage.conf: permission denied"
-    runs-on: 'ubuntu-24.04'
+    name: test-${{ matrix.arch }}
+    runs-on: ${{ (matrix.arch == 'arm64' && 'ubuntu-24.04-arm') || 'ubuntu-24.04' }}
+    strategy:
+      fail-fast: false
+      matrix:
+        arch: [ amd64, arm64 ]
     steps:
       # Needed by podman package - build and runtime dep.
       - name: Install go test deps

--- a/go-worker/pkg/container/docker_test.go
+++ b/go-worker/pkg/container/docker_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/docker/docker/client"
 	"github.com/stretchr/testify/assert"
 	"io"
+	"runtime"
 	"sync"
 	"testing"
 )
@@ -51,6 +52,11 @@ func TestDocker(t *testing.T) {
 	events, err := engine.List(context.Background())
 	assert.NoError(t, err)
 
+	imageId := "63b790fccc9078ab8bb913d94a5d869e19fca9b77712b315da3fa45bb8f14636"
+	if runtime.GOARCH == "arm64" {
+		imageId = "511a44083d3a23416fadc62847c45d14c25cbace86e7a72b2b350436978a0450"
+	}
+
 	expectedEvent := event.Event{
 		Info: event.Info{
 			Container: event.Container{
@@ -59,7 +65,7 @@ func TestDocker(t *testing.T) {
 				Name:           "test_container",
 				Image:          "alpine:3.20.3",
 				ImageDigest:    "sha256:1e42bbe2508154c9126d48c2b8a75420c3544343bf86fd041fb7527e017a4b4a",
-				ImageID:        "63b790fccc9078ab8bb913d94a5d869e19fca9b77712b315da3fa45bb8f14636",
+				ImageID:        imageId,
 				ImageRepo:      "alpine",
 				ImageTag:       "3.20.3",
 				User:           "testuser",

--- a/go-worker/pkg/container/podman_test.go
+++ b/go-worker/pkg/container/podman_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/opencontainers/runtime-spec/specs-go"
 	"github.com/stretchr/testify/assert"
 	"os/user"
+	"runtime"
 	"sync"
 	"testing"
 	"time"
@@ -87,6 +88,11 @@ func TestPodman(t *testing.T) {
 	events, err := engine.List(context.Background())
 	assert.NoError(t, err)
 
+	imageId := "63b790fccc9078ab8bb913d94a5d869e19fca9b77712b315da3fa45bb8f14636"
+	if runtime.GOARCH == "arm64" {
+		imageId = "511a44083d3a23416fadc62847c45d14c25cbace86e7a72b2b350436978a0450"
+	}
+
 	expectedEvent := event.Event{
 		Info: event.Info{
 			Container: event.Container{
@@ -95,7 +101,7 @@ func TestPodman(t *testing.T) {
 				Name:           "test_container",
 				Image:          "docker.io/library/alpine:3.20.3",
 				ImageDigest:    "sha256:1e42bbe2508154c9126d48c2b8a75420c3544343bf86fd041fb7527e017a4b4a",
-				ImageID:        "63b790fccc9078ab8bb913d94a5d869e19fca9b77712b315da3fa45bb8f14636",
+				ImageID:        imageId,
 				ImageRepo:      "docker.io/library/alpine",
 				ImageTag:       "3.20.3",
 				User:           "testuser",


### PR DESCRIPTION
Run test on arm64 runner too.

Extracted from #27 