### PR TITLE
cleanup(test): drop unused gtest libraries.

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -12,4 +12,4 @@ add_executable(test ${SOURCES})
 # project linked libraries
 target_include_directories(test PRIVATE ${CMAKE_SOURCE_DIR}/src ${CMAKE_SOURCE_DIR}/src/matchers ${PLUGIN_SDK_DEPS_INCLUDE} ${PLUGIN_SDK_INCLUDE})
 
-target_link_libraries(test PRIVATE GTest::gtest GTest::gtest_main GTest::gmock GTest::gmock_main container)
+target_link_libraries(test PRIVATE GTest::gtest GTest::gtest_main container)

--- a/test/main.cpp
+++ b/test/main.cpp
@@ -1,7 +1,0 @@
-#include <gtest/gtest.h>
-
-int main(int argc, char** argv)
-{
-    testing::InitGoogleTest(&argc, argv);
-    return RUN_ALL_TESTS();
-}


### PR DESCRIPTION
Also, cleanup test main since we are linking gtest_main lib.

Extract from #27 